### PR TITLE
Pin GitHub Actions to SHA hashes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,8 +7,8 @@ jobs:
     name: Build
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - uses: actions/setup-node@v1
+    - uses: actions/checkout@ee0669bd1cc54295c223e0bb666b733df41de1c5  # v2
+    - uses: actions/setup-node@f1f314fca9dfce2769ece7d933488f076716723e  # v1
       with:
         node-version: '16.x'
     - run: npm install


### PR DESCRIPTION
Pin all GitHub Actions version tags to their corresponding commit SHA hashes for improved supply-chain security.

Original version tags are preserved as comments (e.g. `# v4`).